### PR TITLE
Feature: uploading/view signature 

### DIFF
--- a/src/main/java/github/paz/awardportal/controller/AdminOfficeController.java
+++ b/src/main/java/github/paz/awardportal/controller/AdminOfficeController.java
@@ -44,21 +44,21 @@ public class AdminOfficeController {
 
 
         officeRepository.save(office);
-        return "redirect:/";
+        return "redirect:/offices/list";
     }
 
 
     @PostMapping("/update")
     public String update(@ModelAttribute("office") Office office) {
         officeRepository.save(office);
-        return "redirect:/";
+        return "redirect:/offices/list";
     }
 
 
     @GetMapping("/delete")
     public String delete(@RequestParam("officeId") Long id) {
         officeRepository.deleteById(id);
-        return "redirect:/";
+        return "redirect:/offices/list";
     }
 }
 

--- a/src/main/java/github/paz/awardportal/controller/AdminUserController.java
+++ b/src/main/java/github/paz/awardportal/controller/AdminUserController.java
@@ -64,6 +64,15 @@ public class AdminUserController {
         return "users/update-user-form";
     }
 
+    @GetMapping("/viewSignature")
+    public String viewSignature(@RequestParam("userId") Long id, Model model) {
+        User user = userRepository.getOne(id);
+
+        model.addAttribute("user", user);
+
+        return "users/view-signature";
+    }
+
 
     @PostMapping("/create")
     public String save(@ModelAttribute("user") User user) {
@@ -73,6 +82,7 @@ public class AdminUserController {
         user.setPassword(encodedPassword);
 
         userRepository.save(user);
+
         return "redirect:/users/list";
     }
 

--- a/src/main/java/github/paz/awardportal/model/User/User.java
+++ b/src/main/java/github/paz/awardportal/model/User/User.java
@@ -3,15 +3,19 @@ package github.paz.awardportal.model.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import github.paz.awardportal.model.Award.Award;
 import github.paz.awardportal.model.Office.Office;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+import org.hibernate.annotations.Type;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.util.Base64Utils;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.*;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
+import java.io.InputStream;
 
 @Entity
 @Table(name = "users")
@@ -53,8 +57,8 @@ public class User {
 
     @Column(name = "signature")
     @JsonIgnore
+    @Type(type = "org.hibernate.type.BinaryType")
     private byte[] signature;
-
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "recipient") // TODO - cascade types.
     @JsonIgnore
@@ -72,7 +76,7 @@ public class User {
         this.isAdmin = baseUser.isAdmin();
     }
 
-    public void updateUser(BaseUser update){
+    public void updateUser(BaseUser update) {
         this.firstName = update.getFirstName();
         this.lastName = update.getLastName();
         this.email = update.getEmail();
@@ -85,4 +89,46 @@ public class User {
 
     public User() {
     }
+
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "id=" + id +
+                ", firstName='" + firstName + '\'' +
+                ", lastName='" + lastName + '\'' +
+                ", email='" + email + '\'' +
+                ", password='" + password + '\'' +
+                ", office=" + office +
+                ", isAdmin=" + isAdmin +
+                ", signature=" + Arrays.toString(signature) +
+                ", receivedAwards=" + receivedAwards +
+                '}';
+    }
+
+    // set signature from Multipartfile format which supports upload using <form>
+    public void setSignature(MultipartFile file) throws IOException {
+        this.signature = file.getBytes();
+    }
+
+    // return the signature in base64 string, allow it to be displayed in html
+    public String getEncodedSignature() {
+        try {
+            InputStream inputStream = new ByteArrayInputStream(getSignature());
+            long length = getSignature().length;
+
+            byte[] bytes = new byte[(int) length];
+
+            inputStream.read(bytes);
+            inputStream.close();
+
+            String s = Base64Utils.encodeToString(bytes);
+
+            return s;
+        } catch (Exception e) {
+            System.out.println("Error is:" + e.getMessage());
+            return "";
+        }
+    }
+
 }

--- a/src/main/java/github/paz/awardportal/model/User/User.java
+++ b/src/main/java/github/paz/awardportal/model/User/User.java
@@ -107,13 +107,18 @@ public class User {
     }
 
     // set signature from Multipartfile format which supports upload using <form>
-    public void setSignature(MultipartFile file) throws IOException {
-        this.signature = file.getBytes();
+    public void setSignature(MultipartFile file) {
+        try {
+            this.signature = file.getBytes();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     // return the signature in base64 string, allow it to be displayed in html
     public String getEncodedSignature() {
         try {
+
             InputStream inputStream = new ByteArrayInputStream(getSignature());
             long length = getSignature().length;
 
@@ -126,7 +131,7 @@ public class User {
 
             return s;
         } catch (Exception e) {
-            System.out.println("Error is:" + e.getMessage());
+            e.printStackTrace();
             return "";
         }
     }

--- a/src/main/js/components/User.js
+++ b/src/main/js/components/User.js
@@ -14,6 +14,12 @@ class User extends React.Component {
                 <td>{this.props.user.email}</td>
                 <td>{this.props.user.admin.toString()}</td>
                 <td>{this.props.user.office == (null || undefined) ? "" : this.props.user.office.name}</td>
+                <td >
+                    <a href={"/users/viewSignature?userId=" + this.props.user.id}
+                       class="btn btn-info btn-sm">
+                        View
+                    </a>
+                </td>
                 <td>
                     <a href={"/users/updateForm?userId=" + this.props.user.id}
                        className="btn btn-info btn-sm">

--- a/src/main/js/components/UserList.js
+++ b/src/main/js/components/UserList.js
@@ -18,6 +18,7 @@ class UserList extends Component {
                     <th>Email</th>
                     <th>Admin</th>
                     <th>Office</th>
+                    <th>Signature</th>
                     <th>Update</th>
                     <th>Delete</th>
                 </tr>

--- a/src/main/resources/templates/offices/create-office-form.html
+++ b/src/main/resources/templates/offices/create-office-form.html
@@ -33,11 +33,17 @@
         <input type="text" th:field="*{name}"
                class="form-control mb-4 col-4"
                placeholder="Office Name"
+               required
+               pattern="\S.*\S"
+               title="This field is required"
         >
 
         <input type="text" th:field="*{location}"
                class="form-control mb-4 col-4"
                placeholder="Location"
+               required
+               pattern="\S.*\S"
+               title="This field is required"
         >
 
         <br>

--- a/src/main/resources/templates/offices/update-office-form.html
+++ b/src/main/resources/templates/offices/update-office-form.html
@@ -33,11 +33,17 @@
         <input type="text" th:field="*{name}"
                class="form-control mb-4 col-4"
                placeholder="Office Name"
+               required
+               pattern="\S.*\S"
+               title="This field is required"
         >
 
         <input type="text" th:field="*{location}"
                class="form-control mb-4 col-4"
                placeholder="Location"
+               required
+               pattern="\S.*\S"
+               title="This field is required"
         >
 
         <br>

--- a/src/main/resources/templates/users/create-user-form.html
+++ b/src/main/resources/templates/users/create-user-form.html
@@ -31,19 +31,30 @@
         <!--add hidden form field to handle update-->
         <input type="hidden" th:field="*{id}">
 
+        <!-- regular expression to prevent any white space in beginning or end of the string-->
         <input type="text" th:field="*{firstName}"
                class="form-control mb-4 col-4"
                placeholder="First Name"
+               required
+               pattern="\S.*\S"
+               title="This field is required"
         >
 
         <input type="text" th:field="*{lastName}"
                class="form-control mb-4 col-4"
                placeholder="Last Name"
+               required
+               pattern="\S.*\S"
+               title="This field is required"
         >
 
+        <!-- regular expression prevent any white space in string-->
         <input type="email" th:field="*{email}"
                class="form-control mb-4 col-4"
                placeholder="Email"
+               required
+               pattern="\S+"
+               title="This field is required"
         >
 
 
@@ -51,8 +62,10 @@
                th:field="*{password}"
                class="form-control mb-4 col-4"
                placeholder="Password"
-               required
                minlength="8"
+               required
+               pattern="\S+"
+               title="This field is required"
         >
 
         <p>Is admin?</p>

--- a/src/main/resources/templates/users/create-user-form.html
+++ b/src/main/resources/templates/users/create-user-form.html
@@ -51,6 +51,8 @@
                th:field="*{password}"
                class="form-control mb-4 col-4"
                placeholder="Password"
+               required
+               minlength="8"
         >
 
         <p>Is admin?</p>

--- a/src/main/resources/templates/users/create-user-form.html
+++ b/src/main/resources/templates/users/create-user-form.html
@@ -26,6 +26,7 @@
           th:action="@{/users/create}"
           th:object="${user}"
           method="post"
+          enctype="multipart/form-data"
     >
         <!--add hidden form field to handle update-->
         <input type="hidden" th:field="*{id}">
@@ -63,13 +64,20 @@
                     th:value="${officeChoice.id}" th:text="${officeChoice.name}"
             >
         </select>
+
         <br>
         <br>
+
+        <p>Please upload a file as signature (in jpg format)</p>
+        <input class="file-upload" type="file" name="picture" accept="image/jpeg" th:field="*{signature}">
+        <br>
+        <br>
+
 
         <!--submit button-->
         <button type="submit" class="btn btn-info col-2">Save</button>
-
     </form>
+
 
     <hr>
     <a th:href="@{/users/list}">Back to Users</a>

--- a/src/main/resources/templates/users/list-users.html
+++ b/src/main/resources/templates/users/list-users.html
@@ -39,6 +39,7 @@
             <th>Email</th>
             <th>Admin</th>
             <th>Office</th>
+            <th>Signature</th>
             <th>Update</th>
             <th>Delete</th>
         </tr>
@@ -53,6 +54,13 @@
             <td th:text="${user.email}"/>
             <td th:text="${user.admin}"/>
             <td th:text="${user.office?.name}"/>
+
+            <td>
+                <a th:href="@{/users/viewSignature(userId=${user.id})}"
+                   class="btn btn-info btn-sm">
+                    View
+                </a>
+            </td>
 
             <!-- add an update button-->
             <td>

--- a/src/main/resources/templates/users/update-user-form.html
+++ b/src/main/resources/templates/users/update-user-form.html
@@ -50,6 +50,8 @@
         <input type="password" th:field="*{password}"
                class="form-control mb-4 col-4"
                placeholder="Password"
+               required
+               minlength="8"
         >
 
         <p>Is admin?</p>

--- a/src/main/resources/templates/users/update-user-form.html
+++ b/src/main/resources/templates/users/update-user-form.html
@@ -34,24 +34,35 @@
         <input type="text" th:field="*{firstName}"
                class="form-control mb-4 col-4"
                placeholder="First Name"
+               required
+               pattern="\S.*\S"
+               title="This field is required"
         >
 
         <input type="text" th:field="*{lastName}"
                class="form-control mb-4 col-4"
                placeholder="Last Name"
+               required
+               pattern="\S.*\S"
+               title="This field is required"
         >
 
         <input type="email" th:field="*{email}"
                class="form-control mb-4 col-4"
                placeholder="Email"
+               required
+               pattern="\S+"
+               title="This field is required"
         >
 
 
         <input type="password" th:field="*{password}"
                class="form-control mb-4 col-4"
                placeholder="Password"
-               required
                minlength="8"
+               required
+               pattern="\S+"
+               title="This field is required"
         >
 
         <p>Is admin?</p>

--- a/src/main/resources/templates/users/update-user-form.html
+++ b/src/main/resources/templates/users/update-user-form.html
@@ -26,6 +26,7 @@
           th:action="@{/users/update}"
           th:object="${user}"
           method="post"
+          enctype="multipart/form-data"
     >
         <!--add hidden form field to handle update-->
         <input type="hidden" th:field="*{id}">
@@ -65,6 +66,12 @@
         </select>
         <br/>
         <br/>
+
+        <p>Please upload a file as signature (in jpg format)</p>
+        <input class="file-upload" type="file" name="picture" accept="image/jpeg" th:field="*{signature}">
+        <br>
+        <br>
+
 
         <!--submit button-->
         <button type="submit" class="btn btn-info col-2">Save</button>

--- a/src/main/resources/templates/users/view-signature.html
+++ b/src/main/resources/templates/users/view-signature.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css"
+          integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
+
+    <title>View Signature </title>
+</head>
+
+<body>
+<p th:text="'User: ' +  ${user.firstName} + ' '+ ${user.lastName}"></p>
+<img th:src="@{'data:image/jpg;base64,'+${user.getEncodedSignature()}}"/>
+</body>
+</html>
+
+
+


### PR DESCRIPTION
Feature
- allow uploading a signature image file on create/update user page
- add a view button to view the signature image for the react home page and thymeleaf home page
- after click view button, a view signature page will display to show user signature 

Notes
- set function for signature field takes an input file uploaded in the form, convert it to a byte stream and store it in the database 
- `getEncodedSignature()` decode the byte[] signature data from the database into a string using Base64 encoding, it allows the string to be embedded in the HTML and rendered as a picture by browser 