### PR TITLE
Refactor PDF template to use temp jpg instead of inline Base64 string…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,10 @@ EnvFile
 .factorypath
 .project
 .classpath
+
+### pdflatex output ###
+*.64
+*.aux
+*.log
+*.tex
+signature*

--- a/src/main/java/github/paz/awardportal/pdf/PdfLatexFiles.java
+++ b/src/main/java/github/paz/awardportal/pdf/PdfLatexFiles.java
@@ -16,24 +16,25 @@ public class PdfLatexFiles {
     private Path pdfFile;
     private Path auxFile;
     private Path logFile;
-    // Other byproducts?
+    private Path temp64File;
 
     public PdfLatexFiles(Path texTemplate) {
         String texTemplateFileName = getFileName(texTemplate);
         String pdfFileName = changeExtension(texTemplateFileName, "pdf");
         String auxFileName = changeExtension(texTemplateFileName, "aux");
         String logFileName = changeExtension(texTemplateFileName, "log");
+        String temp64FileName = changeExtension(texTemplateFileName, "64");
 
-        // TODO - need to worry about parent directories, not just file name?
         this.texTemplate = texTemplate;
         pdfFile = Paths.get(pdfFileName);
         auxFile = Paths.get(auxFileName);
         logFile = Paths.get(logFileName);
+        temp64File = Paths.get(temp64FileName);
 
     }
 
     public List<Path> getAll() {
-        return Arrays.asList(texTemplate, pdfFile, auxFile, logFile);
+        return Arrays.asList(texTemplate, pdfFile, auxFile, logFile, temp64File);
     }
 
     private String getFileName(Path path) {

--- a/src/main/resources/templates/awardpdf.ftl
+++ b/src/main/resources/templates/awardpdf.ftl
@@ -4,16 +4,41 @@
     \usepackage{graphicx}
 </#if>
 
-\begin{document}
+\usepackage{color}
+\definecolor{goldenpoppy}{rgb}{0.99, 0.76, 0.0}
+\pagenumbering{gobble}
 
-${recipientName} has been awarded ${awardName} by ${granterName} on ${dateAwarded}
+\begin{document}
+\begin{center}
+\textcolor{goldenpoppy}{{\Huge ${awardName}}}
+
+\bigskip
+
+has been awarded to
+
+\bigskip
+
+{\Huge ${recipientName}}
+
+\bigskip
+
+by
+
+\bigskip
+
+{\large ${granterName}}
+
+\bigskip
 
 <#if signatureImage?has_content>
-    \fbox{\includegraphics[width=3cm]{${signatureImageFile}}}
+    \fbox{\includegraphics[width=10cm]{${signatureImageFile}}}
 <#else>
-
-    (${granterName} has no signature on file.)
-
+    (no signature image on file)
 </#if>
 
+\bigskip
+
+{\large ${dateAwarded}}
+
+\end{center}
 \end{document}


### PR DESCRIPTION
…. Also improve temp file cleanup.

I needed to refactor parts of the PDF generation because inline Base64 images were sometimes too big for pdflatex's text buffer. Also made the layout prettier!