### PR TITLE
Fix errors when submitting Account Recovery form.

### DIFF
--- a/src/main/java/github/paz/awardportal/controller/AccountRecoveryController.java
+++ b/src/main/java/github/paz/awardportal/controller/AccountRecoveryController.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.mail.MessagingException;
-import java.net.URISyntaxException;
 import java.util.Map;
 
 import static org.apache.commons.text.CharacterPredicates.DIGITS;

--- a/src/main/js/api/account-recovery.js
+++ b/src/main/js/api/account-recovery.js
@@ -1,11 +1,17 @@
 import axios from 'axios';
 
-const BASE_URL = "/api/account-recovery/";
+const BASE_URL = '/api/account-recovery/';
 const REQUEST = BASE_URL + 'request';
-const CHANGE_PASSWORD = BASE_URL + "change-password";
+const CHANGE_PASSWORD = BASE_URL + 'change-password';
 
 export async function requestAccountRecovery(data) {
-  return axios.post(REQUEST, data);
+  const headers = {
+    'Content-Type': 'application/json'
+  };
+  const d = {
+    email: data
+  };
+  return axios.post(REQUEST, d, { headers: headers });
 }
 
 export async function changePassword(data) {
@@ -14,5 +20,5 @@ export async function changePassword(data) {
 
 export default {
   requestAccountRecovery,
-  changePassword,
-}
+  changePassword
+};


### PR DESCRIPTION
Looks like these were the problems:

1) @RequestBody doesn't work with the application/x-www-form-urlencoded content type. So, I changed the Content-Type header to application/json

2) The "data" parameter passed to requestAccountRecovery was just the email string, instead of a key-value pair. The server was expecting Map<String, Object>, so this was causing problems. To remedy, I assign this value the "email" key and POST that to the server.
